### PR TITLE
LPS-129065

### DIFF
--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -417,6 +417,12 @@ gradle.beforeProject {
 			}
 		}
 
+		pluginManager.withPlugin("com.liferay.lang.builder") {
+			buildLang {
+				excludedLanguageIds = ["ar", "bg", "ca", "cs", "da", "de", "el", "en_AU", "en_GB", "es", "et", "eu", "fa", "fi", "fr", "fr_CA", "gl", "hi_IN", "hr", "hu", "in", "it", "iw", "ja", "kk", "ko", "lo", "lt", "ms", "nb", "nl", "nl_BE", "pl", "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr_RS", "sr_RS_latin", "sv", "ta_IN", "th", "tr", "uk", "vi", "zh_CN", "zh_TW"]
+			}
+		}
+
 		pluginManager.withPlugin("com.liferay.osgi.plugin") {
 			configurations {
 				xmltask


### PR DESCRIPTION
Hi @brianwulbern, I'm sending this example so its easier to understand.

Adding this code will disable Microsoft translations for the targeted languages across all projects.

The code snippet in this pull excludes everything.  See also [lang/builder/LangBuilder.java#L709](https://github.com/liferay/liferay-portal/blob/master/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java#L709)